### PR TITLE
Added language option support

### DIFF
--- a/Geocoder.js
+++ b/Geocoder.js
@@ -5,6 +5,11 @@ export default {
 
   setApiKey(apiKey) {
     this.apiKey = apiKey;
+    this.language = "";
+  },
+
+  setLanguage(language) {
+    this.language = "language="+language+"&";
   },
 
   async getFromLatLng(lat, lng) {
@@ -17,7 +22,7 @@ export default {
     }
 
     const latLng = `${lat},${lng}`;
-    const url = `${googleApiUrl}?key=${this.apiKey}&latlng=${encodeURI(latLng)}`;
+    const url = `${googleApiUrl}?${this.language}key=${this.apiKey}&latlng=${encodeURI(latLng)}`;
     
     return this.handleUrl(url);
   },
@@ -31,7 +36,7 @@ export default {
       return Promise.reject(new Error("Provided address is invalid"));
     }
 
-    const url = `${googleApiUrl}?key=${this.apiKey}&address=${encodeURI(address)}`;
+    const url = `${googleApiUrl}?${this.language}&key=${this.apiKey}&address=${encodeURI(address)}`;
     
     return this.handleUrl(url);
   },

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A geocoding module for [React Native](https://github.com/facebook/react-native) to transform a description of a location (i.e. street address, town name, etc.) into geographic coordinates (i.e. latitude and longitude) and vice versa.
 
+This module probably works for most javascript frameworks, not just [React Native](https://github.com/facebook/react-native)
+
 This module uses [Google Maps Geocoding API](https://developers.google.com/maps/documentation/geocoding/intro) and requires an API key for purposes of quota management. Please check [this link](https://developers.google.com/maps/documentation/geocoding/get-api-key) out to obtain your API key.
 
 ## Install


### PR DESCRIPTION
The change in the readme might be unnecessary. I don't see why it would work everywhere, I use the module for the web, not React Native, and it works just fine. 

The actual reason for the PR is for adding language option.
It's optional and will not affect anything if not called.
can be called for example setLanguage('en')