### PR TITLE
changing index.d.ts to reflect Geocoder methods as static

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 declare module 'react-native-geocoding' {
     export default class Geocoder {
-        init(apiKey: string, options: Object): void;
-        isInit(): boolean;
-        setApiKey(API_KEY: string): void;
-        from(...params: any[]): Promise<void>;
-        getFromLocation(address: string): Promise<any>;
-        getFromLatLng(lat: number, lng: number): Promise<any>;
+        static init(apiKey: string, options: Object): void;
+        static isInit(): boolean;
+        static setApiKey(API_KEY: string): void;
+        static from(...params: any[]): Promise<void>;
+        static getFromLocation(address: string): Promise<any>;
+        static getFromLatLng(lat: number, lng: number): Promise<any>;
     }
 }


### PR DESCRIPTION
the index.d.ts was listing methods as instance methods, in a way that you would need to call it this way:
```
var geocode = new Geocode();
geocode.init("api_key", options);
```
changed it to behave the way it's supposed to.