### PR TITLE
Feature: Support for address searching within a geolocation context (biased bounds)

### DIFF
--- a/Geocoder.js
+++ b/Geocoder.js
@@ -60,6 +60,10 @@ export default Geocoder = {
 		else if (params[0] instanceof Object)
 			queryParams = {latlng : `${params[0].lat || params[0].latitude},${params[0].lng || params[0].longitude}`};
 
+		// address, {bounds: {northeast: {lat, lng}, southwest: {lan, lng}}}
+		else if (typeof params[0] === 'string' && params[1] instanceof Object)
+			queryParams = {address : params[0], bounds : params[1]};
+
 		// address
 		else if (typeof params[0] === 'string')
 			queryParams = {address : params[0]};
@@ -148,6 +152,25 @@ export default Geocoder = {
 }
 
 /**
+ * Encodes a bounds object into a URL encoded-string.
+ */
+function encodeBounds(bounds) {
+	const southwest = bounds.southwest;
+	const northeast = bounds.northeast;
+	return `${encodeURIComponent(southwest.lat)},${encodeURIComponent(southwest.lng)}|${encodeURIComponent(northeast.lat)},${encodeURIComponent(northeast.lng)}`;
+}
+
+/**
+ * Encodes a component so it can be used safely inside a URL.
+ */
+function encodeComponent(key, value) {
+	if (key === 'bounds') {
+		return encodeBounds(value);
+	}
+	return encodeURIComponent(value);
+}
+
+/**
  * Convert an object into query parameters.
  * @param {Object} object Object to convert.
  * @returns {string} Encoded query parameters.
@@ -155,6 +178,6 @@ export default Geocoder = {
 function toQueryParams(object) {
 	return Object.keys(object)
 		.filter(key => !!object[key])
-		.map(key => key + "=" + encodeURIComponent(object[key]))
+		.map(key => key + "=" + encodeComponent(key, object[key]))
 		.join("&")
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Geocoder.init("xxxxxxxxxxxxxxxxxxxxxxxxx"); // use a valid API key
 // With more options
 // Geocoder.init("xxxxxxxxxxxxxxxxxxxxxxxxx", {language : "en"}); // set the language
 
+// Search by address
 Geocoder.from("Colosseum")
 		.then(json => {
 			var location = json.results[0].geometry.location;
@@ -27,6 +28,17 @@ Geocoder.from("Colosseum")
 		})
 		.catch(error => console.warn(error));
 
+// Search by address, with a biased geo-bounds
+Geocoder.from("Pyramid", {
+		southwest: {lat: 36.05, lng: -115.25},
+		northeast: {lat: 36.16, lng: -115.10}})
+		.then(json => {
+			var location = json.results[0].geometry.location;
+			console.log(location);
+		})
+		.catch(error => console.warn(error));
+
+// Search by geo-location (reserse geo-code)
 Geocoder.from(41.89, 12.49)
 		.then(json => {
         		var addressComponent = json.results[0].address_components[0];


### PR DESCRIPTION
Hi, first of all thanks for this lib 👍 👍 

This PR adds support for the `bounds` parameter for address based searches.
https://developers.google.com/maps/documentation/geocoding/intro?hl=pt#Viewports

This makes it possible to bias your searches to look in a certain area (e.g. your current location), instead of searching globally. This generally improves the quality of the results when you want to search in your current area.

The API has been extended to support an optional second parameter when the first argument is a string. 

The second argument should be a bounds object with the following layout:
```ts
type BoundsType = {
  southeast: {
    lat: number,
    lng: number
  },
  northeast: {
    lat: number,
    lng: number
  }
}
``` 

Usage of extended API:

```js
Geocoder.from("Pyramid", {
		southwest: {lat: 36.05, lng: -115.25},
		northeast: {lat: 36.16, lng: -115.10}})
		.then(json => {
			var location = json.results[0].geometry.location;
			console.log(location);
		})
		.catch(error => console.warn(error));
```

Works like a charm. Let me know if you have any questions.

cheers, Hein